### PR TITLE
Chore/refactor push 2

### DIFF
--- a/apps/dashboard/src/hooks/http-query/use-http-query.tsx
+++ b/apps/dashboard/src/hooks/http-query/use-http-query.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { QUERY_STATUS } from "~/models/enums";
 
-
 // TO DO - fix the typing to use generics of arguments of any type
 // e.g.  <T extends any[]>(...args: T[]) => Promise<T>;
 type QueryFn = (...args: any) => Promise<any>;

--- a/apps/dashboard/src/pages/main-page/main-page.tsx
+++ b/apps/dashboard/src/pages/main-page/main-page.tsx
@@ -4,6 +4,7 @@ import {
   requestPermission,
   pushMessage,
   broadcast,
+  MessageInfo,
 } from "@browser-notify-ui/service-workers";
 import { usePermission } from "~/hooks/permission";
 import { useForm } from "react-hook-form";
@@ -18,6 +19,7 @@ import { useHttpQuery } from "~/hooks/http-query";
 import { useLocalStorage } from "~/hooks/local-storage";
 import { sleep } from "@browser-notify-ui/utils";
 import { nanoid } from "nanoid";
+import axios from "axios";
 
 export const MainPage: React.FC = () => {
   // Get the user's permission to display notification
@@ -90,14 +92,7 @@ export const MainPage: React.FC = () => {
   // but since this is a demo app, we will call it in the browser
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [_, makePushQuery] = useHttpQuery(
-    pushMessage.bind(
-      null,
-      "demo_api_key",
-      "demo-company",
-      "YfZUV8HgaA4tMuH",
-      company,
-      userID
-    )
+    pushMessage.bind(null, "demo_api_key", "demo-company", "YfZUV8HgaA4tMuH")
   ); // bind and fix the credentials arguments as they remain the same
 
   // State to listen to whether the first notification has been received
@@ -117,8 +112,21 @@ export const MainPage: React.FC = () => {
       await sleep(sleepDuration);
 
       try {
-        const result = await makePushQuery(title, message);
-        console.log(result);
+        const info: MessageInfo = {
+          userID,
+          company,
+          notification: {
+            title,
+            body: message,
+            icon: "",
+          },
+        };
+        // send to mock backend, which will call the
+        const { data } = await axios.post(
+          "http://localhost:7071/api/sample-push",
+          info
+        );
+        console.log(data);
       } catch (err) {
         setPendingNotify(false);
         console.error(err);

--- a/libs/service-workers/src/notification/push-message.ts
+++ b/libs/service-workers/src/notification/push-message.ts
@@ -14,28 +14,33 @@ export const pushMessage = async (
   apiKey: string,
   notifySecretName: string,
   notifySecretValue: string,
-  company: string,
-  userID: string,
-  title: string,
-  body: string,
-  icon?: string
+  info: MessageInfo
 ): Promise<Record<string, string>> => {
   const url = "http://localhost:7071/api/notifications";
 
-  const messageInfo: MessageInfo = {
-    userID,
-    company,
-    notification: {
-      title,
-      body,
-      icon,
-    },
-  };
+  if (
+    apiKey.trim() === "" ||
+    notifySecretName.trim() === "" ||
+    notifySecretValue.trim() === ""
+  ) {
+    throw new Error("keys, secrets cannot be empty");
+  }
+  if (info.userID.trim() === "" || info.company.trim() === "") {
+    throw new Error("fields cannot be empty");
+  }
+  if (
+    info.notification == null ||
+    info.notification.title.trim() === "" ||
+    info.notification.body.trim() === ""
+  ) {
+    throw new Error("fields cannot be empty");
+  }
+
   const headers: AxiosRequestHeaders = {
     "API-Key": apiKey,
     "Notify-Secret-Name": notifySecretName,
     "Notify-Secret-Value": notifySecretValue,
   };
-  const result = await axios.post(url, messageInfo, { headers });
+  const result = await axios.post(url, info, { headers });
   return result.data;
 };


### PR DESCRIPTION
Refactor the service worker pushMessage function
Make manual call to mock backend instead of using pushMessage due to exposure of keys and secrets in headers